### PR TITLE
plugin search

### DIFF
--- a/lobot/plugin_manager.py
+++ b/lobot/plugin_manager.py
@@ -50,16 +50,14 @@ class PluginManager(object):
             try:
                 module = importlib.import_module(module_path)
             except ImportError:
-                print("> Could not find plugin: '" + str(module_path) + "' in plugs/ nor sys.path.")
+                pass
             if not module and len(module_path.split('.')) == 1:
                 try:
                     packaged_plugins_dir = "lobot.plugins."
-                    print("> Trying module '" + module_path + "' as '" + packaged_plugins_dir + module_path + "'.")
                     module_path = packaged_plugins_dir + module_path
                     module = importlib.import_module(module_path)
-                    print("> Found " + module_path)
                 except ImportError:
-                    print("> Still could not find " + str(module_path) + ". Skipping known plugin.")
+                    pass
         wrapped = Module(module)
         self._modules[module_path] = wrapped
         return wrapped.plugins

--- a/lobot/plugin_manager.py
+++ b/lobot/plugin_manager.py
@@ -47,17 +47,9 @@ class PluginManager(object):
             module = self._modules[module_path].module
             importlib.reload(module)
         else:
-            try:
-                module = importlib.import_module(module_path)
-            except ImportError:
-                pass
-            if not module and len(module_path.split('.')) == 1:
-                try:
-                    packaged_plugins_dir = "lobot.plugins."
-                    module_path = packaged_plugins_dir + module_path
-                    module = importlib.import_module(module_path)
-                except ImportError:
-                    pass
+            if len(module_path.split('.')) == 1:
+                module_path = "lobot.plugins." + module_path
+            module = importlib.import_module(module_path)
         wrapped = Module(module)
         self._modules[module_path] = wrapped
         return wrapped.plugins

--- a/lobot/plugin_manager.py
+++ b/lobot/plugin_manager.py
@@ -42,11 +42,24 @@ class PluginManager(object):
         return [method for method in plugin.__class__.__dict__.values() if hasattr(method, attribute)]
 
     def load_module(self, module_path: str) -> List[Plugin]:
+        module = None
         if module_path in self._modules:
             module = self._modules[module_path].module
             importlib.reload(module)
         else:
-            module = importlib.import_module(module_path)
+            try:
+                module = importlib.import_module(module_path)
+            except ImportError:
+                print("> Could not find plugin: '" + str(module_path) + "' in plugs/ nor sys.path.")
+            if not module and len(module_path.split('.')) == 1:
+                try:
+                    packaged_plugins_dir = "lobot.plugins."
+                    print("> Trying module '" + module_path + "' as '" + packaged_plugins_dir + module_path + "'.")
+                    module_path = packaged_plugins_dir + module_path
+                    module = importlib.import_module(module_path)
+                    print("> Found " + module_path)
+                except ImportError:
+                    print("> Still could not find " + str(module_path) + ". Skipping known plugin.")
         wrapped = Module(module)
         self._modules[module_path] = wrapped
         return wrapped.plugins

--- a/lobot/plugin_manager.py
+++ b/lobot/plugin_manager.py
@@ -42,14 +42,15 @@ class PluginManager(object):
         return [method for method in plugin.__class__.__dict__.values() if hasattr(method, attribute)]
 
     def load_module(self, module_path: str) -> List[Plugin]:
-        module = None
         if module_path in self._modules:
             module = self._modules[module_path].module
             importlib.reload(module)
         else:
-            if len(module_path.split('.')) == 1:
-                module_path = "lobot.plugins." + module_path
-            module = importlib.import_module(module_path)
+            try:
+                module = importlib.import_module(module_path)
+            except ImportError:
+                if len(module_path.split('.')) == 1:
+                    module = importlib.import_module("lobot.plugins." + module_path)
         wrapped = Module(module)
         self._modules[module_path] = wrapped
         return wrapped.plugins


### PR DESCRIPTION
if plugin not found in ./plugs nor packaged in site-packages, then
if the plugin name is one word name try to find under expected
'lobot.plugins' under site-packages
